### PR TITLE
Update back-to-top button and library subnav styles

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -226,12 +226,12 @@ img {padding-top:10px;}
     visibility: hidden;
     transform: translateY(16px);
     pointer-events: none;
-    transition: opacity 0.35s ease, transform 0.35s ease, box-shadow 0.35s ease;
+    transition: opacity 0.35s ease, transform 0.35s ease, box-shadow 0.35s ease, color 0.25s ease;
     z-index: 9999;
 }
 
 #backToTop i {
-    color: #ffffff;
+    color: currentColor;
     margin-right: 8px;
     transition: color 0.25s ease;
 }
@@ -247,10 +247,6 @@ img {padding-top:10px;}
 #backToTop:hover,
 #backToTop:focus {
     box-shadow: 0 14px 26px rgba(29, 78, 216, 0.45);
-}
-
-#backToTop:hover i,
-#backToTop:focus i {
     color: #1d4ed8;
 }
 
@@ -408,7 +404,7 @@ a.link-nochange:hover {
 }
 
 .subnav {
-    background-color: rgba(255, 255, 255, 0.85);
+    background-color: #f5f7fb;
     padding: 24px 20px;
     border-radius: 18px;
     position: sticky;
@@ -420,6 +416,11 @@ a.link-nochange:hover {
     gap: 12px;
     min-width: 220px;
     align-self: flex-start;
+    transition: background-color 0.2s ease;
+}
+
+.subnav:hover {
+    background-color: #ffffff;
 }
 
 .subnav a {


### PR DESCRIPTION
## Summary
- align the back-to-top icon color with the button text and apply a blue hover state
- refresh the library sub-navigation background to match the page backdrop and brighten on hover

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df9554aae4832d940afa50d6c51b66