### PR TITLE
Adjust spacing between song cards

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -150,7 +150,7 @@ img {padding-top:10px;}
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    gap: 20px;
+    gap: 10px;
 }
 
 .card {
@@ -161,7 +161,7 @@ img {padding-top:10px;}
     align-items: center;
     border-radius: 16px;
     padding: 20px;
-    margin: 10px;
+    margin: 5px;
     width: 220px;
     height: 260px;
     text-align: center;


### PR DESCRIPTION
## Summary
- reduce the flex gap and card margins on the songs grid to tighten spacing between cards

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df9c8bb578832d826f01f146ce4fa0