### PR TITLE
Add horizontal padding to songs list layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -153,6 +153,12 @@ img {padding-top:10px;}
     gap: 10px;
 }
 
+.songs-container {
+    width: 100%;
+    padding: 0 20px;
+    box-sizing: border-box;
+}
+
 .card {
     display: flex;
     position: relative;

--- a/songs.html
+++ b/songs.html
@@ -57,7 +57,7 @@
   <i class="fa-regular fa-star"></i> You have no favourites yet. Click the star on a song to add one.
 </div>
     <div id="noResults">No song found <i class="fa-regular fa-face-sad-tear"></i>, please check your spelling</div>
-    <div class="card-container">
+    <div class="card-container songs-container">
 	<button id="backToTop"><i class="fa-solid fa-angle-up"></i> Back to Top</button>
 
 <!-- Add new songs below, please put them in numbered order -->


### PR DESCRIPTION
## Summary
- add a `songs-container` helper class to give the songs listing extra horizontal padding
- apply the new class to the songs page card container so the cards no longer touch the viewport edges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df9e4e85ac832daf819251288cc479