### PR TITLE
Prevent mobile search blur on iOS devices

### DIFF
--- a/tools/mobile.html
+++ b/tools/mobile.html
@@ -1564,16 +1564,21 @@ $(document).ready(function () {
     });
 
 
-    // Hide keyboard after 1.5s of inactivity
-    let typingTimer;
-    const doneTypingInterval = 1500;
+    // Hide keyboard after 1.5s of inactivity (disabled on iOS to avoid premature blur)
+    const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+        (navigator.userAgent.includes('Mac') && 'ontouchend' in document);
 
-    $('#searchBar').on('input', function () {
-        clearTimeout(typingTimer);
-        typingTimer = setTimeout(() => $('#searchBar').blur(), doneTypingInterval);
-    }).on('keydown', function () {
-        clearTimeout(typingTimer);
-    });
+    if (!isIOS) {
+        let typingTimer;
+        const doneTypingInterval = 1500;
+
+        $('#searchBar').on('input', function () {
+            clearTimeout(typingTimer);
+            typingTimer = setTimeout(() => $('#searchBar').blur(), doneTypingInterval);
+        }).on('keydown', function () {
+            clearTimeout(typingTimer);
+        });
+    }
 
     // Toggle menu
     $('.menu-icon').click(function () {


### PR DESCRIPTION
## Summary
- detect iOS/touch-based Safari when loading the mobile song list
- disable the search field auto-blur timer on iOS to prevent the keyboard from hiding unexpectedly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfa6ab6124832d8b826f2386c0fe63