### PR TITLE
Restyle songs controls and back to top button

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -138,12 +138,68 @@ img {padding-top:10px;}
     margin: 20px 0;
 }
 
-#clearSearch, #Dice, #NZ, #Jazz, #Unlisted, #ShowFavs, #toggleCategories {
-    padding: 8px 15px;
-    margin-left: 5px;
+#clearSearch,
+#Dice,
+#NZ,
+#Jazz,
+#Unlisted,
+#ShowFavs,
+#toggleCategories {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 10px 18px;
+    margin-left: 8px;
     font-size: 16px;
+    font-weight: 600;
+    border-radius: 999px;
+    border: 1px solid rgba(15, 23, 42, 0.25);
+    background: rgba(15, 23, 42, 0.85);
+    color: #ffffff !important;
     cursor: pointer;
-    color:#000 !important;
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18);
+    transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+#clearSearch i,
+#Dice i,
+#NZ i,
+#Jazz i,
+#Unlisted i,
+#ShowFavs i,
+#toggleCategories i {
+    color: currentColor;
+}
+
+#clearSearch:hover,
+#clearSearch:focus,
+#Dice:hover,
+#Dice:focus,
+#NZ:hover,
+#NZ:focus,
+#Jazz:hover,
+#Jazz:focus,
+#Unlisted:hover,
+#Unlisted:focus,
+#ShowFavs:hover,
+#ShowFavs:focus,
+#toggleCategories:hover,
+#toggleCategories:focus {
+    background: #93c5fd;
+    color: #0f172a !important;
+    transform: translateY(-2px);
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.22);
+}
+
+#clearSearch:focus,
+#Dice:focus,
+#NZ:focus,
+#Jazz:focus,
+#Unlisted:focus,
+#ShowFavs:focus,
+#toggleCategories:focus {
+    outline: none;
 }
 
 .card-container {
@@ -227,17 +283,16 @@ img {padding-top:10px;}
     cursor: pointer;
     font-size: 16px;
     border-radius: 999px;
-    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.25);
     opacity: 0;
     visibility: hidden;
     transform: translateY(16px);
     pointer-events: none;
-    transition: opacity 0.35s ease, transform 0.35s ease, box-shadow 0.35s ease, color 0.25s ease;
+    transition: opacity 0.35s ease, transform 0.35s ease, color 0.25s ease;
     z-index: 9999;
 }
 
 #backToTop i {
-    color: currentColor;
+    color: #ffffff;
     margin-right: 8px;
     transition: color 0.25s ease;
 }
@@ -252,19 +307,21 @@ img {padding-top:10px;}
 
 #backToTop:hover,
 #backToTop:focus {
-    box-shadow: 0 14px 26px rgba(29, 78, 216, 0.45);
-    color: #1d4ed8;
+    color: #93c5fd;
+}
+
+#backToTop:hover i,
+#backToTop:focus i {
+    color: #ffffff;
 }
 
 @keyframes backToTopPulse {
     0%,
     100% {
         transform: translateY(0);
-        box-shadow: 0 14px 26px rgba(29, 78, 216, 0.35);
     }
     50% {
         transform: translateY(-6px);
-        box-shadow: 0 22px 32px rgba(29, 78, 216, 0.45);
     }
 }
 


### PR DESCRIPTION
## Summary
- restyle the songs page control buttons with pill styling and animated hover states
- update the back to top button to remove its drop shadow, keep the icon white, and match the navbar hover colour

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e03c835088832db9568cea3b834edf