### PR TITLE
Retone mobile navigation for mobile view

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -103,6 +103,8 @@ img {padding-top:10px;}
 @media (max-width: 600px) {
     .navbar {
         padding: 20px;
+        background: linear-gradient(135deg, rgba(107, 114, 128, 0.95), rgba(55, 65, 81, 0.95));
+        box-shadow: 0 12px 30px rgba(15, 23, 42, 0.28);
     }
     .menu-icon {
         display: block;
@@ -111,7 +113,7 @@ img {padding-top:10px;}
         display: none;
         flex-direction: column;
         gap: 12px;
-        background: rgba(15, 23, 42, 0.95);
+        background: rgba(55, 65, 81, 0.94);
         position: absolute;
         top: 100%;
         left: 0;


### PR DESCRIPTION
## Summary
- update the mobile navbar background gradient to a neutral grey palette instead of blue
- align the dropdown panel color and shadow with the new grey treatment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e048181844832dba0f3c637880f193