### PR TITLE
Adjust mobile navbar color for small screens

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -103,7 +103,7 @@ img {padding-top:10px;}
 @media (max-width: 600px) {
     .navbar {
         padding: 20px;
-        background: linear-gradient(135deg, rgba(107, 114, 128, 0.95), rgba(55, 65, 81, 0.95));
+        background: rgba(75, 85, 99, 0.95);
         box-shadow: 0 12px 30px rgba(15, 23, 42, 0.28);
     }
     .menu-icon {


### PR DESCRIPTION
## Summary
- update the mobile navigation bar background to a grey tone for better contrast on small screens

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e068019ef8832d9e36da40e427ddb3