### PR TITLE
Keep navbar static while retaining lighter styling

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -41,13 +41,14 @@ a:focus {
 img {padding-top:10px;}
 
 .navbar {
-    background: rgba(231, 231, 231, 0.8);
+    background: rgba(243, 244, 246, 0.65);
     padding: 20px 24px;
     text-align: center;
     position: relative;
     width: 100%;
     z-index: 1000;
     box-shadow: none;
+    backdrop-filter: blur(6px);
 }
 
 .navbar a {
@@ -103,6 +104,7 @@ img {padding-top:10px;}
         padding: 20px;
         background: rgba(99, 107, 121, 0.95);
         box-shadow: 0 12px 30px rgba(15, 23, 42, 0.28);
+        backdrop-filter: none;
     }
     .menu-icon {
         display: block;


### PR DESCRIPTION
## Summary
- return each page's navbar markup and script to the static-on-scroll version so it simply scrolls away with the page
- keep the lighter translucent navbar styling while removing the sticky positioning rules from the stylesheet

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0a5821434832d9b7813a5e0b3fb13