### PR TITLE
Add subtle hover animation to navigation links

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -64,6 +64,7 @@ img {padding-top:10px;}
     align-items: center;
 }
 
+
 .nav-item {
     display: inline-flex;
     align-items: center;
@@ -77,7 +78,23 @@ img {padding-top:10px;}
     font-weight: 600;
     text-decoration: none;
     box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.35);
-    transition: background 0.25s ease, color 0.25s ease, box-shadow 0.25s ease;
+    position: relative;
+    overflow: hidden;
+    transition: background 0.25s ease, color 0.25s ease,
+                box-shadow 0.25s ease, transform 0.3s ease;
+}
+
+.nav-item::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    bottom: 6px;
+    width: 0;
+    height: 2px;
+    background: rgba(255, 255, 255, 0.9);
+    transform: translateX(-50%);
+    transition: width 0.3s ease, opacity 0.3s ease;
+    opacity: 0;
 }
 
 .nav-item:hover,
@@ -86,6 +103,23 @@ img {padding-top:10px;}
     color: #fff;
     box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.6);
     text-decoration: none;
+    transform: translateY(-2px);
+}
+
+.nav-item:hover::after,
+.nav-item:focus::after {
+    width: 60%;
+    opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .nav-item {
+        transition: none;
+    }
+
+    .nav-item::after {
+        transition: none;
+    }
 }
 
 .menu-icon {


### PR DESCRIPTION
## Summary
- add an underline reveal and lift animation to navigation links for a more dynamic feel
- respect reduced motion user preferences for the new navigation transitions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0ad06b134832dabbb62fc18414053