### PR TITLE
Fix numeric query behavior in songs search

### DIFF
--- a/songs.html
+++ b/songs.html
@@ -722,9 +722,14 @@
                     .filter(Boolean)
                     .map(field => field.toLowerCase());
 
-                const matchesQuery = searchFields.some(field =>
-                    isNumberSearch ? field.startsWith(normalized) : field.includes(normalized)
-                );
+                const songNumber = String(song.number || '').toLowerCase();
+                const nonNumberFields = [song.title, song.artist, song.dataName]
+                    .filter(Boolean)
+                    .map(field => field.toLowerCase());
+
+                const matchesQuery = isNumberSearch
+                    ? songNumber.startsWith(normalized) || nonNumberFields.some(field => field.includes(normalized))
+                    : searchFields.some(field => field.includes(normalized));
                 const matchesFavorites = !favoritesFilterActive || favorites[song.id];
 
                 if (matchesQuery && matchesFavorites) {


### PR DESCRIPTION
### Motivation
- Users could not find songs where the query is numeric but appears inside the title/artist (e.g. searching `747` did not return "Sydney from a 747").
- The intent is to keep prefix matching for the official `song.number` while allowing substring matches in textual fields so numeric queries behave intuitively.

### Description
- Updated `getFilteredSongs` in `songs.html` to split searchable fields into `songNumber` and `nonNumberFields` and normalize them to lower-case. 
- Changed matching so numeric queries (detected by `/^[0-9]/`) use prefix matching for `song.number` but allow `includes(...)` substring matching against `title`, `artist`, and `dataName`, while non-numeric queries continue to `includes(...)` across all fields.

### Testing
- Served the site with `python3 -m http.server 4173` and verified behavior with a Playwright script that fills `#songSearch` with `747`, which returned `count=1; first=221. Sydney from a 747` and produced a screenshot artifact. 
- Committed the change successfully with `git commit` and confirmed the modified file is `songs.html`. 
- No unit tests were present for search logic; validation was performed via the automated browser test described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69913a58986c832d80ab5ed1acfbf9c1)