### PR TITLE
Improve PDF handling for legacy Android tablets

### DIFF
--- a/songs.html
+++ b/songs.html
@@ -505,6 +505,40 @@
             return songs.find(item => item.id === songId);
         }
 
+        function getAndroidMajorVersion() {
+            const match = navigator.userAgent.match(/Android\s+(\d+)/i);
+            return match ? Number(match[1]) : 0;
+        }
+
+        function getChromeMajorVersion() {
+            const match = navigator.userAgent.match(/(?:Chrome|CriOS)\/(\d+)/i);
+            return match ? Number(match[1]) : 0;
+        }
+
+        function shouldUseAndroidPdfViewer() {
+            const userAgent = navigator.userAgent;
+            const isAndroid = /Android/i.test(userAgent);
+            const isTablet = isAndroid && !/Mobile/i.test(userAgent);
+            if (!isTablet) return false;
+
+            const androidVersion = getAndroidMajorVersion();
+            const chromeVersion = getChromeMajorVersion();
+
+            return (androidVersion > 0 && androidVersion < 10) || (chromeVersion > 0 && chromeVersion < 100);
+        }
+
+        function getPdfDisplayUrl(pdfPath) {
+            if (!shouldUseAndroidPdfViewer()) return pdfPath;
+
+            const absolutePdfUrl = new URL(pdfPath, window.location.href).href;
+            return `https://docs.google.com/gview?embedded=true&url=${encodeURIComponent(absolutePdfUrl)}`;
+        }
+
+        function openSongPdf(song) {
+            if (!song?.pdf) return;
+            window.location.href = getPdfDisplayUrl(song.pdf);
+        }
+
         function normalisePlayHistory(rawHistory) {
             return Object.entries(rawHistory).reduce((normalised, [songId, value]) => {
                 if (Array.isArray(value)) {
@@ -685,6 +719,8 @@
                     event.stopPropagation();
                     const songId = link.getAttribute('data-song-id');
                     handleSongPlay(songId, history);
+                    event.preventDefault();
+                    openSongPdf(getSong(songId));
                 });
             });
 
@@ -699,8 +735,9 @@
             document.querySelectorAll('.song-card').forEach(card => {
                 card.addEventListener('click', () => {
                     const songId = card.getAttribute('data-song-id');
+                    const song = getSong(songId);
                     handleSongPlay(songId, history);
-                    window.location.href = getSong(songId)?.pdf || '#';
+                    openSongPdf(song);
                 });
 
                 card.addEventListener('keydown', (event) => {
@@ -757,7 +794,7 @@
 
             const songLink = document.createElement('a');
             songLink.className = 'link-nochange song-title pdf-link';
-            songLink.href = song.pdf;
+            songLink.href = getPdfDisplayUrl(song.pdf);
             songLink.setAttribute('data-song-id', song.id);
             songLink.setAttribute('data-name', song.dataName || `${song.number} ${song.title} | ${song.artist}`);
             songLink.innerHTML = `<span class="song-number">${song.number}</span> ${song.title}`;


### PR DESCRIPTION
### Motivation
- Some older Android tablets open or re-download PDFs instead of rendering them inline, causing duplicate downloads and a poor user experience.
- The goal is to detect affected tablet browsers and route PDF links through a viewer fallback so the file is displayed instead of re-downloaded.

### Description
- Added detection helpers `getAndroidMajorVersion`, `getChromeMajorVersion`, and `shouldUseAndroidPdfViewer` to identify legacy Android tablet browsers in `songs.html`.
- Introduced `getPdfDisplayUrl` and `openSongPdf` to centralize PDF URL selection and to return a Google Docs Viewer URL for affected devices while leaving direct PDF URLs for modern browsers.
- Updated click handlers so `.pdf-link` anchors, `.song-card` clicks, and keyboard activation all call `openSongPdf(...)` and prevent the default navigation when needed, ensuring consistent handling across interactions.
- Updated the created anchor `href` to use `getPdfDisplayUrl(...)` so links will point to the viewer for legacy tablets and remain direct for other clients.

### Testing
- Ran `git diff --check` to validate whitespace and basic diff issues and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fa171a860832d9f609652e8bb118c)