### PR TITLE
Include song numbers in last-played placeholders and stats UI

### DIFF
--- a/songs.html
+++ b/songs.html
@@ -654,9 +654,11 @@
         }
 
         function handleSongPlay(songId, history) {
+            const song = getSong(songId);
             history[songId] = [Date.now(), ...getSongPlays(history, songId)];
             saveStoredObject(STORAGE_KEY, history);
             updateDisplay(history);
+            setSearchPlaceholder(`Last played: ${song.number}. ${song.title}`);
         }
 
         function updateFavoriteDisplay(favorites) {
@@ -703,7 +705,7 @@
                     <ol class="stats-list">
                         ${topSongs.map(entry => `
                             <li>
-                                <strong>#${entry.rank} ${entry.song.title}</strong><br>
+                                <strong>#${entry.song.number} ${entry.song.title}</strong><br>
                                 ${entry.count} ${entry.count === 1 ? 'play' : 'plays'} · Last played ${formatDateOnly(entry.lastPlayed)}
                             </li>
                         `).join('')}
@@ -903,7 +905,7 @@
                 const searchInput = document.getElementById('songSearch');
                 const lastPlayedEntry = getMostRecentPlayedEntry(history);
                 searchInput.value = '';
-                setSearchPlaceholder(lastPlayedEntry ? `Last song: ${lastPlayedEntry.song.title}` : DEFAULT_SEARCH_PLACEHOLDER);
+                setSearchPlaceholder(lastPlayedEntry ? `Last played: ${lastPlayedEntry.song.number}. ${lastPlayedEntry.song.title}` : DEFAULT_SEARCH_PLACEHOLDER);
                 searchInput.focus();
                 favoritesFilterActive = false;
                 document.getElementById('favoritesFilter').classList.remove('active');
@@ -934,7 +936,7 @@
                 const searchInput = document.getElementById('songSearch');
                 const lastPlayedEntry = getMostRecentPlayedEntry(history);
                 searchInput.value = '';
-                setSearchPlaceholder(lastPlayedEntry ? `Last song: ${lastPlayedEntry.song.title}` : DEFAULT_SEARCH_PLACEHOLDER);
+                setSearchPlaceholder(lastPlayedEntry ? `Last played: ${lastPlayedEntry.song.number}. ${lastPlayedEntry.song.title}` : DEFAULT_SEARCH_PLACEHOLDER);
                 favoritesFilterActive = false;
                 document.getElementById('favoritesFilter').classList.remove('active');
                 const unplayedSongs = applySearchFilter(history, favorites, { unplayedOnly: true });


### PR DESCRIPTION
### Motivation
- Make it clearer which song was referenced by showing each song's number alongside its title in last-played placeholders and rankings.
- Ensure the search placeholder updates immediately when a song is played so users see the recently played song number and title.

### Description
- Updated the stats dialog rendering in `showStatsDialog` to display `entry.song.number` before the song title in the rankings list.
- Updated `clearSearch` and `randomSong` button handlers to set the placeholder to `Last played: <number>. <title>` when a most-recent entry exists.
- Added `const song = getSong(songId);` to `handleSongPlay` and call `setSearchPlaceholder` with the played song's number and title so the placeholder reflects the song immediately after play.

### Testing
- No automated tests were run for this UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30ef3e577c832db6bd71e3cd36a01a)