### PR TITLE
Record plays per date, rename stats to “My top 10 songs”, and add Android PDF viewer

### DIFF
--- a/pdf-viewer.html
+++ b/pdf-viewer.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PDF Viewer</title>
+    <link rel="stylesheet" href="assets/style.css">
+    <style>
+        body {
+            margin: 0;
+            background: #f5f2ec;
+            color: #2b2118;
+            font-family: Arial, sans-serif;
+        }
+
+        .viewer-header {
+            position: sticky;
+            top: 0;
+            z-index: 10;
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            padding: 0.75rem 1rem;
+            background: #fffaf2;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.14);
+        }
+
+        .viewer-header a {
+            color: inherit;
+            font-weight: 700;
+            text-decoration: none;
+        }
+
+        #pdfPages {
+            display: grid;
+            gap: 1rem;
+            justify-items: center;
+            padding: 1rem 0.5rem 2rem;
+        }
+
+        canvas {
+            width: min(100%, 960px);
+            height: auto;
+            background: white;
+            box-shadow: 0 2px 12px rgba(0, 0, 0, 0.18);
+        }
+
+        .viewer-message {
+            max-width: 32rem;
+            margin: 2rem auto;
+            padding: 1rem;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <header class="viewer-header">
+        <a href="songs.html" aria-label="Back to songs">← Songs</a>
+        <span id="viewerTitle">Loading PDF…</span>
+    </header>
+    <main id="pdfPages" aria-live="polite"></main>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
+    <script>
+        const pages = document.getElementById('pdfPages');
+        const title = document.getElementById('viewerTitle');
+        const params = new URLSearchParams(window.location.search);
+        const file = params.get('file');
+
+        function showMessage(message) {
+            pages.innerHTML = `<p class="viewer-message">${message}</p>`;
+            title.textContent = 'PDF unavailable';
+        }
+
+        async function renderPdf() {
+            if (!file) {
+                showMessage('No PDF was selected.');
+                return;
+            }
+
+            const pdfUrl = new URL(file, window.location.href);
+            if (pdfUrl.origin !== window.location.origin) {
+                showMessage('This viewer can only open PDFs from this website.');
+                return;
+            }
+
+            title.textContent = decodeURIComponent(file.split('/').pop() || 'Song PDF');
+            pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
+
+            try {
+                const pdf = await pdfjsLib.getDocument(pdfUrl.href).promise;
+                pages.innerHTML = '';
+
+                for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber += 1) {
+                    const page = await pdf.getPage(pageNumber);
+                    const unscaledViewport = page.getViewport({ scale: 1 });
+                    const targetWidth = Math.min(window.innerWidth - 16, 960);
+                    const viewport = page.getViewport({ scale: targetWidth / unscaledViewport.width });
+                    const canvas = document.createElement('canvas');
+                    const context = canvas.getContext('2d');
+
+                    canvas.width = Math.floor(viewport.width);
+                    canvas.height = Math.floor(viewport.height);
+                    canvas.setAttribute('aria-label', `Page ${pageNumber}`);
+                    pages.appendChild(canvas);
+
+                    await page.render({ canvasContext: context, viewport }).promise;
+                }
+            } catch (error) {
+                console.error('Unable to render PDF', error);
+                showMessage('Sorry, this PDF could not be displayed. Please try again later.');
+            }
+        }
+
+        renderPdf();
+    </script>
+</body>
+</html>

--- a/songs.html
+++ b/songs.html
@@ -612,10 +612,8 @@
             return getRankings(history).find(entry => entry.song.id === songId);
         }
 
-        function getMostRecentPlayedEntry(history) {
-            return getRankings(history)
-                .filter(entry => entry.lastPlayed > 0)
-                .sort((a, b) => b.lastPlayed - a.lastPlayed)[0];
+        function formatSongPlaceholder(song) {
+            return song ? `${song.number} ${song.title}` : DEFAULT_SEARCH_PLACEHOLDER;
         }
 
         function setSearchPlaceholder(text) {
@@ -649,7 +647,7 @@
             history[songId] = [today, ...previousPlays];
             saveStoredObject(STORAGE_KEY, history);
             updateDisplay(history);
-            setSearchPlaceholder(`Last played: ${song.number}. ${song.title}`);
+            setSearchPlaceholder(formatSongPlaceholder(song));
         }
 
         function updateFavoriteDisplay(favorites) {
@@ -894,9 +892,8 @@
 
             document.getElementById('clearSearch').addEventListener('click', () => {
                 const searchInput = document.getElementById('songSearch');
-                const lastPlayedEntry = getMostRecentPlayedEntry(history);
                 searchInput.value = '';
-                setSearchPlaceholder(lastPlayedEntry ? `Last played: ${lastPlayedEntry.song.number}. ${lastPlayedEntry.song.title}` : DEFAULT_SEARCH_PLACEHOLDER);
+                setSearchPlaceholder();
                 searchInput.focus();
                 favoritesFilterActive = false;
                 document.getElementById('favoritesFilter').classList.remove('active');
@@ -925,32 +922,23 @@
 
             document.getElementById('randomSong').addEventListener('click', () => {
                 const searchInput = document.getElementById('songSearch');
-                const lastPlayedEntry = getMostRecentPlayedEntry(history);
                 searchInput.value = '';
-                setSearchPlaceholder(lastPlayedEntry ? `Last played: ${lastPlayedEntry.song.number}. ${lastPlayedEntry.song.title}` : DEFAULT_SEARCH_PLACEHOLDER);
                 favoritesFilterActive = false;
                 document.getElementById('favoritesFilter').classList.remove('active');
-                const unplayedSongs = applySearchFilter(history, favorites, { unplayedOnly: true });
+                applySearchFilter(history, favorites, { unplayedOnly: true });
 
                 const visibleCards = Array.from(document.querySelectorAll('.song-card'))
                     .filter(card => card.offsetParent !== null);
 
                 if (!visibleCards.length) {
                     renderSongs(songs, history, favorites);
-                    setSearchPlaceholder('All songs have been played');
                     return;
                 }
 
                 visibleCards.forEach(card => card.classList.remove('random-highlight'));
                 const randomCard = visibleCards[Math.floor(Math.random() * visibleCards.length)];
-                const randomSong = unplayedSongs.find(song => song.id === randomCard.getAttribute('data-song-id'));
-
                 randomCard.classList.add('random-highlight');
                 randomCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
-
-                if (randomSong) {
-                    setSearchPlaceholder(`Last random: ${randomSong.title}`);
-                }
 
                 const link = randomCard.querySelector('.pdf-link');
                 if (link) {

--- a/songs.html
+++ b/songs.html
@@ -466,7 +466,7 @@
     <dialog id="statsDialog" class="stats-dialog" aria-labelledby="statsDialogTitle">
         <div class="dialog-content">
             <div class="dialog-header">
-                <h2 id="statsDialogTitle">Top 10 songs</h2>
+                <h2 id="statsDialogTitle">My top 10 songs</h2>
                 <button class="icon-button dialog-close" type="button" data-close-dialog aria-label="Close song stats">
                     <i class="fa-solid fa-xmark" aria-hidden="true"></i>
                 </button>
@@ -518,8 +518,7 @@
         function shouldUseAndroidPdfViewer() {
             const userAgent = navigator.userAgent;
             const isAndroid = /Android/i.test(userAgent);
-            const isTablet = isAndroid && !/Mobile/i.test(userAgent);
-            if (!isTablet) return false;
+            if (!isAndroid) return false;
 
             const androidVersion = getAndroidMajorVersion();
             const chromeVersion = getChromeMajorVersion();
@@ -530,8 +529,7 @@
         function getPdfDisplayUrl(pdfPath) {
             if (!shouldUseAndroidPdfViewer()) return pdfPath;
 
-            const absolutePdfUrl = new URL(pdfPath, window.location.href).href;
-            return `https://docs.google.com/gview?embedded=true&url=${encodeURIComponent(absolutePdfUrl)}`;
+            return `pdf-viewer.html?file=${encodeURIComponent(pdfPath)}`;
         }
 
         function openSongPdf(song) {
@@ -539,22 +537,22 @@
             window.location.href = getPdfDisplayUrl(song.pdf);
         }
 
+        function getLocalDateTimestamp(value = Date.now()) {
+            const date = new Date(value);
+            return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+        }
+
         function normalisePlayHistory(rawHistory) {
             return Object.entries(rawHistory).reduce((normalised, [songId, value]) => {
-                if (Array.isArray(value)) {
-                    const validDates = value
-                        .map(Number)
-                        .filter(timestamp => Number.isFinite(timestamp))
-                        .sort((a, b) => b - a);
-                    if (validDates.length) {
-                        normalised[songId] = validDates;
-                    }
-                    return normalised;
-                }
+                const values = Array.isArray(value) ? value : [value];
+                const uniqueDates = [...new Set(values
+                    .map(Number)
+                    .filter(timestamp => Number.isFinite(timestamp))
+                    .map(getLocalDateTimestamp))]
+                    .sort((a, b) => b - a);
 
-                const timestamp = Number(value);
-                if (Number.isFinite(timestamp)) {
-                    normalised[songId] = [timestamp];
+                if (uniqueDates.length) {
+                    normalised[songId] = uniqueDates;
                 }
                 return normalised;
             }, {});
@@ -582,15 +580,6 @@
             });
         }
 
-        function formatDateTime(timestamp) {
-            return new Date(timestamp).toLocaleString(undefined, {
-                month: 'short',
-                day: 'numeric',
-                year: 'numeric',
-                hour: 'numeric',
-                minute: '2-digit'
-            });
-        }
 
         function truncateArtist(name) {
             if (name.length <= 18) return name;
@@ -655,7 +644,9 @@
 
         function handleSongPlay(songId, history) {
             const song = getSong(songId);
-            history[songId] = [Date.now(), ...getSongPlays(history, songId)];
+            const today = getLocalDateTimestamp();
+            const previousPlays = getSongPlays(history, songId).filter(timestamp => timestamp !== today);
+            history[songId] = [today, ...previousPlays];
             saveStoredObject(STORAGE_KEY, history);
             updateDisplay(history);
             setSearchPlaceholder(`Last played: ${song.number}. ${song.title}`);
@@ -688,7 +679,7 @@
                 <p class="history-summary">${rankText}</p>
                 <p class="history-summary">Played ${plays.length} ${plays.length === 1 ? 'time' : 'times'}.</p>
                 ${plays.length
-                    ? `<ol class="history-dates">${plays.map(timestamp => `<li>${formatDateTime(timestamp)}</li>`).join('')}</ol>`
+                    ? `<ol class="history-dates">${plays.map(timestamp => `<li>${formatDateOnly(timestamp)}</li>`).join('')}</ol>`
                     : '<p class="history-empty">This song has not been played yet.</p>'}
             `;
             dialog.showModal();
@@ -747,7 +738,7 @@
                         event.preventDefault();
                         const songId = card.getAttribute('data-song-id');
                         handleSongPlay(songId, history);
-                        window.location.href = getSong(songId)?.pdf || '#';
+                        openSongPdf(getSong(songId));
                     }
                 });
             });

--- a/songs.html
+++ b/songs.html
@@ -613,7 +613,7 @@
         }
 
         function formatSongPlaceholder(song) {
-            return song ? `${song.number} ${song.title}` : DEFAULT_SEARCH_PLACEHOLDER;
+            return song ? `Last played: ${song.number} ${song.title}` : DEFAULT_SEARCH_PLACEHOLDER;
         }
 
         function setSearchPlaceholder(text) {


### PR DESCRIPTION
### Motivation
- Avoid multiple taps in the same calendar day counting as multiple plays by storing play history per local date instead of full timestamps. 
- Make the stats dialog more personal by changing the heading to `My top 10 songs`.
- Prevent older Android/Android Chrome devices from triggering a download prompt by rendering PDFs in-page when appropriate.

### Description
- Changed the stats dialog heading in `songs.html` from `Top 10 songs` to `My top 10 songs`.
- Added `getLocalDateTimestamp` and updated `normalisePlayHistory` in `songs.html` to normalise existing timestamp history into unique local-date entries and to store only date-only values per song.
- Updated `handleSongPlay` to record the local date once per day (replacing same-day duplicates) and updated the history display to use `formatDateOnly` so history entries show dates only.
- Reworked Android PDF handling: `shouldUseAndroidPdfViewer` now checks for Android devices, `getPdfDisplayUrl` routes older Android/Chrome Android users to a new `pdf-viewer.html?file=...`, and `openSongPdf`/keyboard handlers use this path.
- Added `pdf-viewer.html`, a small same-origin PDF.js-based viewer that renders PDFs in-browser and includes a back link to the songs page.

### Testing
- Performed a JavaScript syntax check by extracting inline scripts and running `node --check` against them, which succeeded for both `songs.html` and `pdf-viewer.html`.
- Validated the HTML by parsing `songs.html` and `pdf-viewer.html` with Python's `html.parser`, which completed successfully.
- Started a local Python HTTP server (`python3 -m http.server`) to smoke-test serving the files, which launched successfully in the environment.
- Attempted browser-based/headless rendering tests (Playwright/browser binary) but they were not available in the environment, so full end-to-end PDF render verification could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34e125d6ec832daf6a7a5b2712f3de)