### PR TITLE
Add songs2 page and enforce in-site PDF viewer flow

### DIFF
--- a/events.html
+++ b/events.html
@@ -15,7 +15,7 @@
 	<span class="menu-icon">&#9776;</span>
         <div class="nav-links">
         <a class="nav-item" href="index.html">Home</a>
-        <a class="nav-item" href="songs.html">Songs</a>
+        <a class="nav-item" href="songs2.html">Songs</a>
 		<a class="nav-item" href="events.html" id="events-nav">Events<span class="nav-alert" aria-hidden="true"></span></a>
 		<a class="nav-item" href="library.html">Library</a>
 		</div>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <span class="menu-icon" aria-label="Toggle navigation" aria-expanded="false">&#9776;</span>
     <nav class="nav-links">
       <a class="nav-item" href="index.html">Home</a>
-      <a class="nav-item" href="songs.html">Songs</a>
+      <a class="nav-item" href="songs2.html">Songs</a>
       <a class="nav-item" href="events.html" id="events-nav">Events<span class="nav-alert" aria-hidden="true"></span></a>
       <a class="nav-item" href="library.html">Library</a>
     </nav>
@@ -39,7 +39,7 @@
 
       <h2>Let's Jam!</h2>
       <p>When you arrive, grab any of the available tables, or see if there are some free spots with other players.</p>
-      <p>We go from table to table asking which song you want to play. You can find all the songs here <a class="nav-item hero-button" href="songs.html"><i class="fa-solid fa-music"></i>  Songs</a></p>
+      <p>We go from table to table asking which song you want to play. You can find all the songs here <a class="nav-item hero-button" href="songs2.html"><i class="fa-solid fa-music"></i>  Songs</a></p>
       <p><i class="fa-solid fa-mug-hot"></i> We take a break at 8pm for a cup of coffee and a chat.</p>
       <p><i class="fa fa-coins"></i> Please bring a gold coin with you to help cover various events throughout the year.</p>
 

--- a/library.html
+++ b/library.html
@@ -36,7 +36,7 @@ ul li {
         <span class="menu-icon">&#9776;</span>
         <div class="nav-links">
         <a class="nav-item" href="index.html">Home</a>
-        <a class="nav-item" href="songs.html">Songs</a>
+        <a class="nav-item" href="songs2.html">Songs</a>
                 <a class="nav-item" href="events.html" id="events-nav">Events<span class="nav-alert" aria-hidden="true"></span></a>
                 <a class="nav-item" href="library.html">Library</a>
                 </div>
@@ -58,7 +58,7 @@ ul li {
       <div class="section-body">
         <p>Learning the ukulele is a fun, beginner-friendly way to explore music. Joining a group like the Sou'West Strummers lets you practice in a supportive, social setting while improving your skills and getting tips from experienced players.</p>
           <ul>
-            All our songs can be found on the <a class="nav-item nav-button" href="songs.html"><i class="fa fa-music"></i>  Songs</a> page, it has a few features
+            All our songs can be found on the <a class="nav-item nav-button" href="songs2.html"><i class="fa fa-music"></i>  Songs</a> page, it has a few features
             <li>You can search songs by number, name, and artist</li>
             <li>New to Ukulele? Type <b>learn</b> to filter easy songs using basic chords (A, Am, C, C7, G, F). </li>
             <li>You can favorite songs or roll the dice for a random one, clicking the X will clear the search and favourite filter</li>

--- a/midwinter.html
+++ b/midwinter.html
@@ -32,7 +32,7 @@ iframe {max-width: 100%;}
 	<span class="menu-icon">&#9776;</span>
         <div class="nav-links">
         <a class="nav-item" href="index.html">Home</a>
-        <a class="nav-item" href="songs.html">Songs</a>
+        <a class="nav-item" href="songs2.html">Songs</a>
 		<a class="nav-item" href="events.html" id="events-nav">Events<span class="nav-alert" aria-hidden="true"></span></a>
 		<a class="nav-item" href="library.html">Library</a>
 		</div>

--- a/pdf-viewer.html
+++ b/pdf-viewer.html
@@ -55,7 +55,7 @@
 </head>
 <body>
     <header class="viewer-header">
-        <a href="songs.html" aria-label="Back to songs">← Songs</a>
+        <a href="songs2.html" aria-label="Back to songs">← Songs</a>
         <span id="viewerTitle">Loading PDF…</span>
     </header>
     <main id="pdfPages" aria-live="polite"></main>

--- a/songs2.html
+++ b/songs2.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Songs - Sou'West Strummers</title>
-    <meta http-equiv="refresh" content="0; url=songs2.html">
+    <title>Songs2 - Sou'West Strummers</title>
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico">
     <link rel="stylesheet" href="assets/style.css">
     <script src="assets/site.js"></script>
@@ -405,9 +404,6 @@
             }
         }
     </style>
-    <script>
-        window.location.replace('songs2.html' + window.location.search + window.location.hash);
-    </script>
 </head>
 <body>
     <div class="navbar">
@@ -531,8 +527,6 @@
         }
 
         function getPdfDisplayUrl(pdfPath) {
-            if (!shouldUseAndroidPdfViewer()) return pdfPath;
-
             return `pdf-viewer.html?file=${encodeURIComponent(pdfPath)}`;
         }
 

--- a/tools.html
+++ b/tools.html
@@ -14,7 +14,7 @@
 	<span class="menu-icon">&#9776;</span>
         <div class="nav-links">
         <a class="nav-item" href="index.html">Home</a>
-        <a class="nav-item" href="songs.html">Songs</a>
+        <a class="nav-item" href="songs2.html">Songs</a>
 		<a class="nav-item" href="events.html" id="events-nav">Events<span class="nav-alert" aria-hidden="true"></span></a>
 		<a class="nav-item" href="library.html">Library</a>
 		</div>

--- a/tools/blinkers.html
+++ b/tools/blinkers.html
@@ -38,7 +38,7 @@
 <div class="nav-links">
 		<div class="nav-links">
         <a class="nav-item" href="index.html">Home</a>
-        <a class="nav-item" href="songs.html">Songs</a>
+        <a class="nav-item" href="songs2.html">Songs</a>
 		<a class="nav-item" href="events.html">Events</a>
 		<a class="nav-item" href="library.html">Library</a>
 		</div>


### PR DESCRIPTION
### Motivation
- Provide a second version of the Songs page and ensure song PDFs always open via the in-site PDF viewer instead of linking directly to raw PDF files.
- Keep the existing `songs.html` URL functional by redirecting it to the new `songs2.html` entry point so external links do not break.

### Description
- Added `songs2.html` as a copy of the existing songs UI and changed its `getPdfDisplayUrl` implementation to always return `pdf-viewer.html?file=...` so PDFs open in the viewer.
- Updated the site navigation across `index.html`, `events.html`, `library.html`, `tools.html`, `midwinter.html`, and `tools/blinkers.html` to point to `songs2.html` instead of `songs.html`.
- Updated `pdf-viewer.html` back link to point at `songs2.html` and modified `songs.html` to perform a redirect to `songs2.html` via a meta refresh and a `window.location.replace` script that preserves query string and hash.

### Testing
- Ran an HTML parse smoke check with `python3 - <<'PY' ... HTMLParser().feed(...) ... PY` which completed successfully.
- Ran enforcement assertions with `python3 - <<'PY' ... songs2 enforcement checks ... PY` that validated the `getPdfDisplayUrl` change and that no remaining `href="songs.html"` references exist in the updated pages, and those checks passed.
- Attempted a local HTTP server + `curl` smoke check using `python3 -m http.server` and `curl`, but the server was not reachable in this environment so that runtime check failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cc9a43b30832d8e8dd3d990d05e56)