### PR TITLE
Make songs page the default (remove songs2 redirect)

### DIFF
--- a/events.html
+++ b/events.html
@@ -15,7 +15,7 @@
 	<span class="menu-icon">&#9776;</span>
         <div class="nav-links">
         <a class="nav-item" href="index.html">Home</a>
-        <a class="nav-item" href="songs2.html">Songs</a>
+        <a class="nav-item" href="songs.html">Songs</a>
 		<a class="nav-item" href="events.html" id="events-nav">Events<span class="nav-alert" aria-hidden="true"></span></a>
 		<a class="nav-item" href="library.html">Library</a>
 		</div>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <span class="menu-icon" aria-label="Toggle navigation" aria-expanded="false">&#9776;</span>
     <nav class="nav-links">
       <a class="nav-item" href="index.html">Home</a>
-      <a class="nav-item" href="songs2.html">Songs</a>
+      <a class="nav-item" href="songs.html">Songs</a>
       <a class="nav-item" href="events.html" id="events-nav">Events<span class="nav-alert" aria-hidden="true"></span></a>
       <a class="nav-item" href="library.html">Library</a>
     </nav>
@@ -39,7 +39,7 @@
 
       <h2>Let's Jam!</h2>
       <p>When you arrive, grab any of the available tables, or see if there are some free spots with other players.</p>
-      <p>We go from table to table asking which song you want to play. You can find all the songs here <a class="nav-item hero-button" href="songs2.html"><i class="fa-solid fa-music"></i>  Songs</a></p>
+      <p>We go from table to table asking which song you want to play. You can find all the songs here <a class="nav-item hero-button" href="songs.html"><i class="fa-solid fa-music"></i>  Songs</a></p>
       <p><i class="fa-solid fa-mug-hot"></i> We take a break at 8pm for a cup of coffee and a chat.</p>
       <p><i class="fa fa-coins"></i> Please bring a gold coin with you to help cover various events throughout the year.</p>
 

--- a/library.html
+++ b/library.html
@@ -36,7 +36,7 @@ ul li {
         <span class="menu-icon">&#9776;</span>
         <div class="nav-links">
         <a class="nav-item" href="index.html">Home</a>
-        <a class="nav-item" href="songs2.html">Songs</a>
+        <a class="nav-item" href="songs.html">Songs</a>
                 <a class="nav-item" href="events.html" id="events-nav">Events<span class="nav-alert" aria-hidden="true"></span></a>
                 <a class="nav-item" href="library.html">Library</a>
                 </div>
@@ -58,7 +58,7 @@ ul li {
       <div class="section-body">
         <p>Learning the ukulele is a fun, beginner-friendly way to explore music. Joining a group like the Sou'West Strummers lets you practice in a supportive, social setting while improving your skills and getting tips from experienced players.</p>
           <ul>
-            All our songs can be found on the <a class="nav-item nav-button" href="songs2.html"><i class="fa fa-music"></i>  Songs</a> page, it has a few features
+            All our songs can be found on the <a class="nav-item nav-button" href="songs.html"><i class="fa fa-music"></i>  Songs</a> page, it has a few features
             <li>You can search songs by number, name, and artist</li>
             <li>New to Ukulele? Type <b>learn</b> to filter easy songs using basic chords (A, Am, C, C7, G, F). </li>
             <li>You can favorite songs or roll the dice for a random one, clicking the X will clear the search and favourite filter</li>

--- a/midwinter.html
+++ b/midwinter.html
@@ -32,7 +32,7 @@ iframe {max-width: 100%;}
 	<span class="menu-icon">&#9776;</span>
         <div class="nav-links">
         <a class="nav-item" href="index.html">Home</a>
-        <a class="nav-item" href="songs2.html">Songs</a>
+        <a class="nav-item" href="songs.html">Songs</a>
 		<a class="nav-item" href="events.html" id="events-nav">Events<span class="nav-alert" aria-hidden="true"></span></a>
 		<a class="nav-item" href="library.html">Library</a>
 		</div>

--- a/pdf-viewer.html
+++ b/pdf-viewer.html
@@ -55,7 +55,7 @@
 </head>
 <body>
     <header class="viewer-header">
-        <a href="songs2.html" aria-label="Back to songs">← Songs</a>
+        <a href="songs.html" aria-label="Back to songs">← Songs</a>
         <span id="viewerTitle">Loading PDF…</span>
     </header>
     <main id="pdfPages" aria-live="polite"></main>

--- a/songs.html
+++ b/songs.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Songs - Sou'West Strummers</title>
-    <meta http-equiv="refresh" content="0; url=songs2.html">
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico">
     <link rel="stylesheet" href="assets/style.css">
     <script src="assets/site.js"></script>
@@ -405,16 +404,13 @@
             }
         }
     </style>
-    <script>
-        window.location.replace('songs2.html' + window.location.search + window.location.hash);
-    </script>
 </head>
 <body>
     <div class="navbar">
         <span class="menu-icon" aria-label="Toggle navigation" aria-expanded="false">&#9776;</span>
           <div class="nav-links">
             <a class="nav-item" href="index.html">Home</a>
-            <a class="nav-item" href="songs2.html">Songs</a>
+            <a class="nav-item" href="songs.html">Songs</a>
             <a class="nav-item" href="events.html" id="events-nav">Events<span class="nav-alert" aria-hidden="true"></span></a>
             <a class="nav-item" href="library.html">Library</a>
         </div>

--- a/songs2.html
+++ b/songs2.html
@@ -410,7 +410,7 @@
         <span class="menu-icon" aria-label="Toggle navigation" aria-expanded="false">&#9776;</span>
           <div class="nav-links">
             <a class="nav-item" href="index.html">Home</a>
-            <a class="nav-item" href="songs2.html">Songs</a>
+            <a class="nav-item" href="songs.html">Songs</a>
             <a class="nav-item" href="events.html" id="events-nav">Events<span class="nav-alert" aria-hidden="true"></span></a>
             <a class="nav-item" href="library.html">Library</a>
         </div>

--- a/tools.html
+++ b/tools.html
@@ -14,7 +14,7 @@
 	<span class="menu-icon">&#9776;</span>
         <div class="nav-links">
         <a class="nav-item" href="index.html">Home</a>
-        <a class="nav-item" href="songs2.html">Songs</a>
+        <a class="nav-item" href="songs.html">Songs</a>
 		<a class="nav-item" href="events.html" id="events-nav">Events<span class="nav-alert" aria-hidden="true"></span></a>
 		<a class="nav-item" href="library.html">Library</a>
 		</div>

--- a/tools/blinkers.html
+++ b/tools/blinkers.html
@@ -38,7 +38,7 @@
 <div class="nav-links">
 		<div class="nav-links">
         <a class="nav-item" href="index.html">Home</a>
-        <a class="nav-item" href="songs2.html">Songs</a>
+        <a class="nav-item" href="songs.html">Songs</a>
 		<a class="nav-item" href="events.html">Events</a>
 		<a class="nav-item" href="library.html">Library</a>
 		</div>


### PR DESCRIPTION
### Motivation
- Make `songs.html` the primary Songs page so visitors land on the intended default instead of being redirected to `songs2.html`.
- Ensure site navigation and in-page links reference the default Songs page consistently.

### Description
- Removed the automatic redirect from `songs.html` by deleting the `<meta http-equiv="refresh">` and the `window.location.replace('songs2.html'...)` script so `songs.html` now loads directly.
- Updated navigation and song-related links in `index.html`, `library.html`, `events.html`, `tools.html`, `tools/blinkers.html`, `midwinter.html`, and `pdf-viewer.html` to point to `songs.html` instead of `songs2.html`.
- Updated the navigation link inside `songs2.html` to point back to `songs.html` so `songs2.html` remains available as an optional page without being the default.
- Committed the changes with the message `Make songs page the default`.

### Testing
- Ran a Python check that scanned relevant files to ensure no `href="songs2.html"`, `url=songs2.html`, or `location.replace('songs2.html'...)` default references remain, and it passed.
- Served the site locally with `python3 -m http.server 8000` and verified `curl -I http://127.0.0.1:8000/songs.html` returned HTTP 200, and the check passed.
- Confirmed the repository state and created a commit containing the updates, and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ccc335dd0832db5211eac8524acc6)