### PR TITLE
Preserve songs2 return link when opening PDF viewer

### DIFF
--- a/pdf-viewer.html
+++ b/pdf-viewer.html
@@ -55,7 +55,7 @@
 </head>
 <body>
     <header class="viewer-header">
-        <a href="songs.html" aria-label="Back to songs">← Songs</a>
+        <a id="backToSongs" href="songs.html" aria-label="Back to songs">← Songs</a>
         <span id="viewerTitle">Loading PDF…</span>
     </header>
     <main id="pdfPages" aria-live="polite"></main>
@@ -66,6 +66,13 @@
         const title = document.getElementById('viewerTitle');
         const params = new URLSearchParams(window.location.search);
         const file = params.get('file');
+        const backToSongs = document.getElementById('backToSongs');
+        const returnTo = params.get('returnTo');
+        const allowedSongPages = new Set(['songs.html', 'songs2.html']);
+
+        if (allowedSongPages.has(returnTo)) {
+            backToSongs.href = returnTo;
+        }
 
         function showMessage(message) {
             pages.innerHTML = `<p class="viewer-message">${message}</p>`;

--- a/songs2.html
+++ b/songs2.html
@@ -527,7 +527,7 @@
         }
 
         function getPdfDisplayUrl(pdfPath) {
-            return `pdf-viewer.html?file=${encodeURIComponent(pdfPath)}`;
+            return `pdf-viewer.html?file=${encodeURIComponent(pdfPath)}&returnTo=songs2.html`;
         }
 
         function openSongPdf(song) {


### PR DESCRIPTION
### Motivation
- Ensure that when a PDF is opened from `songs2.html` the viewer's back link returns the user to `songs2.html` instead of always going to `songs.html`.

### Description
- Update `getPdfDisplayUrl` in `songs2.html` to append `&returnTo=songs2.html` to viewer links.
- Add an `id="backToSongs"` anchor in `pdf-viewer.html` and update its script to read the `returnTo` query parameter and, when it matches a safe page from the set `['songs.html','songs2.html']`, set the back link to that value while otherwise defaulting to `songs.html`.

### Testing
- Ran `git diff --check` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ccdc70f48832dba8c35c85f4fdca0)