### PR TITLE
Add alternate Songs page link, simplify PDF viewer, and surface last-played placeholder in songs2

### DIFF
--- a/library.html
+++ b/library.html
@@ -64,6 +64,8 @@ ul li {
             <li>You can favorite songs or roll the dice for a random one, clicking the X will clear the search and favourite filter</li>
             <li>You can also find the last time you played a song</li>
           </ul>
+          <p>If the songs page is not working correctly for you, try the alternate songs page:</p>
+          <p><a class="nav-item nav-button" href="songs2.html"><i class="fa fa-music"></i> Visit Songs2</a></p>
 <br>
 If you prefer a physical copy of the songs, song books can be purchased on Thursday nights for $30
 <br>

--- a/pdf-viewer.html
+++ b/pdf-viewer.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>PDF Viewer</title>
+    <title>Sou West Strummers</title>
     <link rel="stylesheet" href="assets/style.css">
     <style>
         body {
@@ -11,24 +11,6 @@
             background: #f5f2ec;
             color: #2b2118;
             font-family: Arial, sans-serif;
-        }
-
-        .viewer-header {
-            position: sticky;
-            top: 0;
-            z-index: 10;
-            display: flex;
-            align-items: center;
-            gap: 1rem;
-            padding: 0.75rem 1rem;
-            background: #fffaf2;
-            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.14);
-        }
-
-        .viewer-header a {
-            color: inherit;
-            font-weight: 700;
-            text-decoration: none;
         }
 
         #pdfPages {
@@ -54,29 +36,16 @@
     </style>
 </head>
 <body>
-    <header class="viewer-header">
-        <a id="backToSongs" href="songs.html" aria-label="Back to songs">← Songs</a>
-        <span id="viewerTitle">Loading PDF…</span>
-    </header>
     <main id="pdfPages" aria-live="polite"></main>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
     <script>
         const pages = document.getElementById('pdfPages');
-        const title = document.getElementById('viewerTitle');
         const params = new URLSearchParams(window.location.search);
         const file = params.get('file');
-        const backToSongs = document.getElementById('backToSongs');
-        const returnTo = params.get('returnTo');
-        const allowedSongPages = new Set(['songs.html', 'songs2.html']);
-
-        if (allowedSongPages.has(returnTo)) {
-            backToSongs.href = returnTo;
-        }
 
         function showMessage(message) {
             pages.innerHTML = `<p class="viewer-message">${message}</p>`;
-            title.textContent = 'PDF unavailable';
         }
 
         async function renderPdf() {
@@ -91,7 +60,6 @@
                 return;
             }
 
-            title.textContent = decodeURIComponent(file.split('/').pop() || 'Song PDF');
             pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
 
             try {

--- a/songs2.html
+++ b/songs2.html
@@ -610,6 +610,15 @@
             return getRankings(history).find(entry => entry.song.id === songId);
         }
 
+        function getMostRecentlyPlayedSong(history) {
+            const latest = Object.entries(history)
+                .map(([songId, plays]) => ({ songId, lastPlayed: Array.isArray(plays) ? plays[0] : 0 }))
+                .filter(entry => entry.lastPlayed)
+                .sort((a, b) => b.lastPlayed - a.lastPlayed)[0];
+
+            return latest ? getSong(latest.songId) : null;
+        }
+
         function formatSongPlaceholder(song) {
             return song ? `Last played: ${song.number} ${song.title}` : DEFAULT_SEARCH_PLACEHOLDER;
         }
@@ -882,6 +891,7 @@
 
             saveStoredObject(STORAGE_KEY, history);
             renderSongs(songs, history, favorites);
+            setSearchPlaceholder(formatSongPlaceholder(getMostRecentlyPlayedSong(history)));
 
             document.getElementById('songSearch').addEventListener('input', () => {
                 setSearchPlaceholder();


### PR DESCRIPTION
### Motivation
- Provide an alternate entry to the songs UI when the primary songs page may not work for some users.
- Simplify the standalone PDF viewer by removing the sticky header and back-link logic to make the viewer more self-contained.
- Improve UX on `songs2.html` by showing the most-recently played song in the search placeholder.

### Description
- `library.html`: added an alternate songs link and call-to-action pointing to `songs2.html` so users can try `songs2` if `songs.html` is not working.
- `pdf-viewer.html`: removed the header markup and associated CSS and script logic that managed a back-link and viewer title, and updated the document title to "Sou West Strummers"; retained the PDF rendering logic and error messaging.
- `songs2.html`: added `getMostRecentlyPlayedSong(history)` and set the search input placeholder on `DOMContentLoaded` to reflect the last-played song when available.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ce3561ac8832d8c3a11f62258e27e)