### PR TITLE
Swap songs pages and update Library to point to backup

### DIFF
--- a/library.html
+++ b/library.html
@@ -64,8 +64,7 @@ ul li {
             <li>You can favorite songs or roll the dice for a random one, clicking the X will clear the search and favourite filter</li>
             <li>You can also find the last time you played a song</li>
           </ul>
-          <p>If the songs page is not working correctly for you, try the alternate songs page:</p>
-          <p><a class="nav-item nav-button" href="songs2.html"><i class="fa fa-music"></i> Visit Songs2</a></p>
+          <p>If somethings not working right, go back to the <a class="nav-item nav-button" href="songs-backup.html"><i class="fa fa-music"></i> previous version</a>.</p>
 <br>
 If you prefer a physical copy of the songs, song books can be purchased on Thursday nights for $30
 <br>

--- a/songs-backup.html
+++ b/songs-backup.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Songs2 - Sou'West Strummers</title>
+    <title>Songs Backup - Sou'West Strummers</title>
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico">
     <link rel="stylesheet" href="assets/style.css">
     <script src="assets/site.js"></script>
@@ -421,7 +421,7 @@
 
     <main>
         <div class="page-header">
-            <h1><i class="fa-solid fa-music"></i> Songs</h1>
+            <h1><i class="fa-solid fa-music"></i> Songs Backup</h1>
             <div class="search-row">
                 <label class="search-bar" for="songSearch">
                     <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
@@ -527,7 +527,9 @@
         }
 
         function getPdfDisplayUrl(pdfPath) {
-            return `pdf-viewer.html?file=${encodeURIComponent(pdfPath)}&returnTo=songs2.html`;
+            if (!shouldUseAndroidPdfViewer()) return pdfPath;
+
+            return `pdf-viewer.html?file=${encodeURIComponent(pdfPath)}`;
         }
 
         function openSongPdf(song) {
@@ -608,15 +610,6 @@
 
         function getSongRanking(history, songId) {
             return getRankings(history).find(entry => entry.song.id === songId);
-        }
-
-        function getMostRecentlyPlayedSong(history) {
-            const latest = Object.entries(history)
-                .map(([songId, plays]) => ({ songId, lastPlayed: Array.isArray(plays) ? plays[0] : 0 }))
-                .filter(entry => entry.lastPlayed)
-                .sort((a, b) => b.lastPlayed - a.lastPlayed)[0];
-
-            return latest ? getSong(latest.songId) : null;
         }
 
         function formatSongPlaceholder(song) {
@@ -891,7 +884,6 @@
 
             saveStoredObject(STORAGE_KEY, history);
             renderSongs(songs, history, favorites);
-            setSearchPlaceholder(formatSongPlaceholder(getMostRecentlyPlayedSong(history)));
 
             document.getElementById('songSearch').addEventListener('input', () => {
                 setSearchPlaceholder();

--- a/songs.html
+++ b/songs.html
@@ -527,9 +527,7 @@
         }
 
         function getPdfDisplayUrl(pdfPath) {
-            if (!shouldUseAndroidPdfViewer()) return pdfPath;
-
-            return `pdf-viewer.html?file=${encodeURIComponent(pdfPath)}`;
+            return `pdf-viewer.html?file=${encodeURIComponent(pdfPath)}&returnTo=songs.html`;
         }
 
         function openSongPdf(song) {
@@ -610,6 +608,15 @@
 
         function getSongRanking(history, songId) {
             return getRankings(history).find(entry => entry.song.id === songId);
+        }
+
+        function getMostRecentlyPlayedSong(history) {
+            const latest = Object.entries(history)
+                .map(([songId, plays]) => ({ songId, lastPlayed: Array.isArray(plays) ? plays[0] : 0 }))
+                .filter(entry => entry.lastPlayed)
+                .sort((a, b) => b.lastPlayed - a.lastPlayed)[0];
+
+            return latest ? getSong(latest.songId) : null;
         }
 
         function formatSongPlaceholder(song) {
@@ -884,6 +891,7 @@
 
             saveStoredObject(STORAGE_KEY, history);
             renderSongs(songs, history, favorites);
+            setSearchPlaceholder(formatSongPlaceholder(getMostRecentlyPlayedSong(history)));
 
             document.getElementById('songSearch').addEventListener('input', () => {
                 setSearchPlaceholder();


### PR DESCRIPTION
### Motivation
- Replace the alternate songs experience (previously `songs2.html`) with the primary `songs.html` while preserving the prior page as a safe fallback named `songs-backup.html`.
- Ensure PDF viewer return targets, navigation and in-page behaviours are consistent after the swap so users can easily return to the correct page.
- Give editors a clear route back to the older songs page from the Library when something isn't working.

### Description
- Renamed `songs2.html` to `songs-backup.html` and updated the page `<title>` and main `<h1>` to “Songs Backup”.
- Moved the alternate songs implementation onto `songs.html`, updated its PDF viewer `getPdfDisplayUrl` to include `&returnTo=songs.html`, and added `getMostRecentlyPlayedSong` plus a call to `setSearchPlaceholder(formatSongPlaceholder(getMostRecentlyPlayedSong(history)))` so the search placeholder shows the last-played song.
- Adjusted `songs-backup.html` to keep the Android-specific PDF viewer behaviour and removed the placeholder-last-played injection to keep it as the fallback copy.
- Updated `library.html` copy to: "If somethings not working right, go back to the previous version" and linked that text to `songs-backup.html`.

### Testing
- Ran `python3` assertions to verify that `songs.html` exists, `songs-backup.html` exists, `songs2.html` no longer exists, `songs.html` contains `returnTo=songs.html`, and `library.html` contains the `href="songs-backup.html"` link, and those checks passed.
- Searched repository root HTML files to confirm no remaining `songs2` references and verified the expected replacements with `rg`/searches.
- Ran `git diff --check` to catch whitespace/format issues and no problems were reported.
- Started a local `python3 -m http.server` to spot-check pages, and an attempt to capture a headless screenshot failed because Playwright is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ee34e111c832d81bb3f71bb404960)