### PR TITLE
Update events listing

### DIFF
--- a/events.html
+++ b/events.html
@@ -22,22 +22,11 @@
     </div>
     <div class="banner"></div>
 	<h1><i class="fa-solid fa-thumbtack"></i> Events</h1>
-    <span id="events-update-date" data-date="2026-05-22" data-delay-hours="1" hidden></span>
+    <span id="events-update-date" data-date="2026-07-16" data-delay-hours="1" hidden></span>
 	
 	<h2> <i class="fa-solid fa-calendar"></i> 2026</h2>
 	<div class="event-container">
 
-<div class="event">
-<h2><i class="fa fa-guitar"></i> Geraldine Ukefest</h2>
-<i class="fa-regular fa-clock"></i> 3rd July - 5th July 2026
-<br><i class="fa-solid fa-location-dot"></i> Geraldine
-<br><br>
-<a class="nav-item nav-button" href="https://events.humanitix.com/geraldine-ukefest-2026?fbclid=IwY2xjawOy0mVleHRuA2FlbQIxMQBicmlkETEzc0tmSk0zRkoxV2pobmw1c3J0YwZhcHBfaWQQMjIyMDM5MTc4ODIwMDg5MgABHnLAmOl3S9Si0IOjFbraxNj7745gj5GQ7dJ9IDewdimDUxxd_RRiIDfoP-sv_aem_y2XcbZn9l8bTy3fq235oYw
-">Buy Tickets</a>
-	<br><br>
-<a class="nav-item nav-button" href="https://www.facebook.com/geraldineukefest/">More info</a>
-<br>
-</div>
 
 <div class="event">
 <h2><i class="fa fa-guitar"></i> Te Anua Ukefest</h2>
@@ -47,6 +36,15 @@
 <a class="nav-item nav-button" href="https://events.humanitix.com/te-anau-ukulele-festival-tuf26">Buy Tickets</a>
 	<br><br>
 <p><a class="nav-item nav-button" href="https://www.facebook.com/TeAnauUkuleleFestival/">More info</a></p>
+<br>
+</div>
+
+<div class="event">
+<h2><i class="fa-solid fa-sun"></i> 2026 Mid Summer Strum</h2>
+<i class="fa-regular fa-clock"></i> Saturday, 3 October 2026, 1pm - 4pm
+<br><i class="fa-solid fa-location-dot"></i> Garfield Recreation Centre
+<br><br>
+<a class="nav-item nav-button" href="midwinter.html">2026 Event Info and Pictures</a>
 <br>
 </div>
   


### PR DESCRIPTION
### Motivation
- Remove the outdated Geraldine Ukefest entry from the 2026 events list and add the new Mid Summer Strum event so the site reflects current event scheduling.
- Ensure the events page `events-update-date` is refreshed so the navigation alert and last-visit logic recognise the change.

### Description
- Removed the `Geraldine Ukefest` event block from `events.html` and its associated links and dates.
- Added a `2026 Mid Summer Strum` event block to `events.html` using the same structure and button pattern as the 2025 Midwinter Strum, with date/time `Saturday, 3 October 2026, 1pm - 4pm` and location `Garfield Recreation Centre`.
- Updated the `events-update-date` element in `events.html` to `data-date="2026-07-16"` so the site treats this as a recent update.

### Testing
- Ran `rg -n "Geraldine Ukefest|2026 Mid Summer Strum|Garfield Recreation Centre" events.html` and confirmed the new `2026 Mid Summer Strum` entry exists and `Geraldine Ukefest` is no longer present (passed).
- Ran `git diff --check` to validate whitespace and diff issues and it returned clean (passed).
- Attempted a browser automation verification using `playwright`, but the environment lacks the `playwright` package so that check could not run (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5880a4acd4832d89ced6fd434dfbf7)