### PR TITLE
Update 2026 Mid Summer Strum event details

### DIFF
--- a/events.html
+++ b/events.html
@@ -42,9 +42,7 @@
 <div class="event">
 <h2><i class="fa-solid fa-sun"></i> 2026 Mid Summer Strum</h2>
 <i class="fa-regular fa-clock"></i> Saturday, 3 October 2026, 1pm - 4pm
-<br><i class="fa-solid fa-location-dot"></i> Garfield Recreation Centre
-<br><br>
-<a class="nav-item nav-button" href="midwinter.html">2026 Event Info and Pictures</a>
+<br><i class="fa-solid fa-location-dot"></i> Darfield Recreation Centre, 92 North Terrace, Darfield
 <br>
 </div>
   


### PR DESCRIPTION
### Motivation
- Align the 2026 Mid Summer Strum listing with the venue/address used in 2025 and remove an unnecessary event info button.

### Description
- Modified `events.html` to replace "Garfield Recreation Centre" with "Darfield Recreation Centre, 92 North Terrace, Darfield" and removed the `a.nav-item.nav-button` "2026 Event Info and Pictures" button from the 2026 Mid Summer Strum entry.

### Testing
- Ran `git diff --check` and `git status --short` to verify there are no whitespace or repository issues, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5882054ab4832dba18b257a573479a)