### PR TITLE
Add dynamic "Sou West Strummers" footer with current month and year

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -441,6 +441,13 @@ img {padding-top:10px;}
     opacity: 1;
 }
 
+.site-footer {
+    padding: 20px 24px;
+    border-top: 1px solid #e2e8f0;
+    color: #475569;
+    font-size: 0.875rem;
+}
+
 @media (max-width: 900px) {
     .hero {
         flex-direction: column-reverse;

--- a/index.html
+++ b/index.html
@@ -53,9 +53,18 @@
       <!-- add as many slides as you like -->
     </div>
   </div>
+
+  <footer class="site-footer">
+    Sou West Strummers - <time id="current-month-year"></time>
+  </footer>
   
   <script>
     $(function(){
+      const now = new Date();
+      $('#current-month-year')
+        .attr('datetime', `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`)
+        .text(new Intl.DateTimeFormat('en-NZ', { month: 'short', year: 'numeric' }).format(now));
+
       // slideshow
       let slides = $('.hero-slideshow .slide'),
           idx = 0,


### PR DESCRIPTION
### Motivation
- Provide a simple, visible footer on the home page that displays the group name and a localized abbreviated month and year so visitors can see a current "last updated" indicator.

### Description
- Inserted a footer element containing `Sou West Strummers - <time id="current-month-year"></time>` into `index.html` at the end of the page.
- Added inline JavaScript to compute the current date, set a machine-readable `datetime` on the `<time>` element, and render the localized month and year using `Intl.DateTimeFormat('en-NZ', { month: 'short', year: 'numeric' })` in `index.html`.
- Added `.site-footer` styling to `assets/style.css` to provide padding, a top border, subdued text color, and an appropriate font size.
- No other page behavior was altered beyond the slideshow and existing scripts remaining intact.

### Testing
- Parsed `index.html` with a Python `HTMLParser` invocation (`python - <<'PY' ...`) which completed successfully. 
- Extracted inline scripts and validated them with `node --check /tmp/index-inline.js`, which reported no syntax errors. 
- Ran `git diff --check` to ensure there are no whitespace or diff problems, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d227a3d4c832d9138bb0238d3d865)