### PR TITLE
Update unplayed song message

### DIFF
--- a/songs.html
+++ b/songs.html
@@ -689,7 +689,7 @@
                 <p class="history-summary">Played ${plays.length} ${plays.length === 1 ? 'time' : 'times'}.</p>
                 ${plays.length
                     ? `<ol class="history-dates">${plays.map(timestamp => `<li>${formatDateOnly(timestamp)}</li>`).join('')}</ol>`
-                    : '<p class="history-empty">This song has not been played yet.</p>'}
+                    : '<p class="history-empty">You\'ve not played this song yet.</p>'}
             `;
             dialog.showModal();
         }


### PR DESCRIPTION
### Motivation
- Adjust the empty song-history message on the songs page to use the requested, more conversational wording `You've not played this song yet.`

### Description
- Replace the previous empty-history string in `songs.html` with the new message inside the `showHistoryDialog` body template.

### Testing
- Verified the edited script fragment passes syntax checking with `node --check`, confirmed the new message appears exactly once with `rg`, confirmed the old message is absent, and `git diff --check` returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e42b75f2c832db6fafda8992d564c)